### PR TITLE
Implemented splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,97 @@ resulting in ([jsonata link](http://try.jsonata.org/B1ctn36ub)):
 }
 ```
 
+## Array splitting
+
+Sometimes it is necessary to generate multiple outgoing message from a single incoming message, for example when:
+* You want to split a large incoming array to process each item individually to save resources (RAM)
+* You want to process a complex nested structure by splitting it into multiple less complex pieces
+* You want to split large item into many smaller items to increase reliability of the processing
+
+You can do it with JSONata transformer - when result of your transformation is an ``iterable`` (e.g. Array) then
+component action will emit each result of the array individually.
+
+Taking the example above and following JSONata expression:
+
+```jsonata
+Account.Order.Product[]
+```
+
+will produce following JSON:
+
+```json
+[
+  {
+    "Product Name": "Bowler Hat",
+    "ProductID": 858383,
+    "SKU": "0406654608",
+    "Description": {
+      "Colour": "Purple",
+      "Width": 300,
+      "Height": 200,
+      "Depth": 210,
+      "Weight": 0.75
+    },
+    "Price": 34.45,
+    "Quantity": 2
+  },
+  {
+    "Product Name": "Trilby hat",
+    "ProductID": 858236,
+    "SKU": "0406634348",
+    "Description": {
+      "Colour": "Orange",
+      "Width": 300,
+      "Height": 200,
+      "Depth": 210,
+      "Weight": 0.6
+    },
+    "Price": 21.67,
+    "Quantity": 1
+  }
+]
+```
+
+which will however be automatically split into two messages and emitted as following:
+
+__Message 1__:
+
+```json
+{
+    "Product Name": "Bowler Hat",
+    "ProductID": 858383,
+    "SKU": "0406654608",
+    "Description": {
+      "Colour": "Purple",
+      "Width": 300,
+      "Height": 200,
+      "Depth": 210,
+      "Weight": 0.75
+    },
+    "Price": 34.45,
+    "Quantity": 2
+  }
+```
+
+and __Message 2__:
+
+```json
+{
+    "Product Name": "Trilby hat",
+    "ProductID": 858236,
+    "SKU": "0406634348",
+    "Description": {
+      "Colour": "Orange",
+      "Width": 300,
+      "Height": 200,
+      "Depth": 210,
+      "Weight": 0.6
+    },
+    "Price": 21.67,
+    "Quantity": 1
+  }
+```
+
 ## License
 
 Apache-2.0 © [elastic.io GmbH](http://elastic.io)

--- a/lib/actions/transform.js
+++ b/lib/actions/transform.js
@@ -10,16 +10,22 @@ const jsonata = require('jsonata');
  * @param cfg configuration that is account information and configuration field values
  */
 function processAction(msg, cfg) {
-    const expression = cfg.expression;
-    console.log('Evaluating expression="%s"', expression);
-    const compiledExpression = jsonata(expression);
-    const result = compiledExpression.evaluate(msg.body);
-    console.log('Evaluation completed, result=%j', result);
-    if (result === undefined || result === null || Object.keys(result).length === 0) {
-        return Promise.resolve();
-    } else {
-        return Promise.resolve(eioUtils.newMessageWithBody(result));
+  const expression = cfg.expression;
+  console.log('Evaluating expression="%s"', expression);
+  const compiledExpression = jsonata(expression);
+  const result = compiledExpression.evaluate(msg.body);
+  console.log('Evaluation completed, result=%j', result);
+  if (result === undefined || result === null || Object.keys(result).length === 0) {
+    return Promise.resolve();
+  }
+  if (typeof result[Symbol.iterator] === 'function') {
+            // We have an iterator as result
+    for (const item of result) {
+      this.emit('data', eioUtils.newMessageWithBody(item));
     }
+    return Promise.resolve();
+  }
+  return Promise.resolve(eioUtils.newMessageWithBody(result));
 }
 
 module.exports.process = processAction;

--- a/spec/transform.spec.js
+++ b/spec/transform.spec.js
@@ -2,32 +2,68 @@
 const expect = require('chai').expect;
 const transform = require('../lib/actions/transform');
 const eioUtils = require('elasticio-node').messages;
+const EventEmitter = require('events');
+
+class TestEmitter extends EventEmitter {
+
+  constructor(done) {
+    super();
+    this.data = [];
+    this.end = 0;
+    this.error = [];
+
+    this.on('data', value => this.data.push(value));
+    this.on('error', value => {
+      this.error.push(value);
+      console.error(value.stack || value);
+    });
+    this.on('end', () => {
+      this.end++;
+      done();
+    });
+  }
+
+}
 
 describe('Transformation test', () => {
-
-    it('should handle simple transforms', () => {
-        return transform.process(eioUtils.newMessageWithBody({
-            first: 'Renat',
-            last: 'Zubairov'
-        }), {
-            expression: `{ "fullName": first & " " & last }`
-        }).then(result => {
-            expect(result.body).to.deep.equal({
-                fullName: 'Renat Zubairov'
-            });
-        });
+  it('should handle simple transforms', () => {
+    return transform.process(eioUtils.newMessageWithBody({
+      first: 'Renat',
+      last: 'Zubairov'
+    }), {
+      expression: `{ "fullName": first & " " & last }`
+    }).then(result => {
+      expect(result.body).to.deep.equal({
+        fullName: 'Renat Zubairov'
+      });
     });
+  });
 
-    it('should not produce an empty message if transformation returns undefined', () => {
-        return transform.process(eioUtils.newMessageWithBody({
-            first: 'Renat',
-            last: 'Zubairov'
-        }), {
-            expression: `$[foo=2].({ "foo": boom })`
-        }).then(result => {
-            expect(result).to.be.an('undefined');
-        });
+  it('should not produce an empty message if transformation returns undefined', () => {
+    return transform.process(eioUtils.newMessageWithBody({
+      first: 'Renat',
+      last: 'Zubairov'
+    }), {
+      expression: `$[foo=2].({ "foo": boom })`
+    }).then(result => {
+      expect(result).to.be.an('undefined');
     });
+  });
 
-
+  it('should not produce multiple messages when transformation result is an array', () => {
+    const emitter = new TestEmitter();
+    return transform.process.call(emitter, eioUtils.newMessageWithBody({
+      items: [
+                {id: 'one'},
+                {id: 'two'}
+      ]
+    }), {
+      expression: `items`
+    }).then(result => {
+      expect(result).to.be.an('undefined');
+      expect(emitter.data.length).to.be.equal(2);
+      expect(emitter.data[0].body).to.be.deep.equal({id: 'one'});
+      expect(emitter.data[1].body).to.be.deep.equal({id: 'two'});
+    });
+  });
 });


### PR DESCRIPTION
If result is array then instead of passing naked array further the splitting will be applied to the results.

Documentation and example is here - https://github.com/elasticio/jsonata-transform-component/tree/split#array-splitting